### PR TITLE
Repos Base Details

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ curl  -H "X-Auth-User:admin" \
 
 ```
 
+## Extra REST APIs
+
+All requests must include authentication.
+
+# /rest/auth-token/1.0/user
+
+Fetches a user's username and token.
+
+# /rest/auth-token/1.0/user/regenerate-token
+
+Regenerates a user's token.
+
+# /rest/auth-token/1.0/admin
+
+Fetches the admin details.
+
 ## UI Elements
 
 ### Administration config

--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ curl  -H "X-Auth-User:admin" \
 
 All requests must include authentication.
 
-# /rest/auth-token/1.0/user
+### `[GET] /rest/auth-token/1.0/user`
 
 Fetches a user's username and token.
 
-# /rest/auth-token/1.0/user/regenerate-token
+### `[GET] /rest/auth-token/1.0/user/regenerate-token`
 
 Regenerates a user's token.
 
-# /rest/auth-token/1.0/admin
+### `[GET, PUT] /rest/auth-token/1.0/admin`
 
-Fetches the admin details.
+Fetches and updates the admin details.
 
 ## UI Elements
 

--- a/src/main/java/com/thundermoose/plugins/admin/AdminConfigDao.java
+++ b/src/main/java/com/thundermoose/plugins/admin/AdminConfigDao.java
@@ -39,7 +39,7 @@ public class AdminConfigDao {
       config.setProjectPaths(new ProjectPaths(true, true, true));
     }
     if(config.getRepoPaths() == null) {
-      config.setRepoPaths(new RepoPaths(true, true, true, true, true, true));
+      config.setRepoPaths(new RepoPaths(true, true, true, true, true, true, true));
     }
     setAdminConfig(config);
   }
@@ -84,7 +84,8 @@ public class AdminConfigDao {
                 BooleanUtils.toBoolean((String) settings.get(repoFiles)),
                 BooleanUtils.toBoolean((String) settings.get(repoPullRequests)),
                 BooleanUtils.toBoolean((String) settings.get(repoBranchPermissions)),
-                BooleanUtils.toBoolean((String) settings.get(buildStatus))
+                BooleanUtils.toBoolean((String) settings.get(buildStatus)),
+                BooleanUtils.toBoolean((String) settings.get(baseDetails))
             ));
           }
 
@@ -125,6 +126,7 @@ public class AdminConfigDao {
           settings.put(repoPullRequests, BooleanUtils.toStringTrueFalse(config.getRepoPaths().getPullRequests()));
           settings.put(repoBranchPermissions, BooleanUtils.toStringTrueFalse(config.getRepoPaths().getBranchPermissions()));
           settings.put(buildStatus, BooleanUtils.toStringTrueFalse(config.getRepoPaths().getBuildStatus()));
+          settings.put(baseDetails, BooleanUtils.toStringTrueFalse(config.getRepoPaths().getBaseDetails()));
         }
 
         setCache(config);
@@ -158,4 +160,5 @@ public class AdminConfigDao {
   public static final String repoPullRequests = repoPathPrefix + ".pullRequests";
   public static final String repoBranchPermissions = repoPathPrefix + ".branchPermissions";
   public static final String buildStatus = repoPathPrefix + ".buildStatus";
+  public static final String baseDetails = repoPathPrefix + ".baseDetails";
 }

--- a/src/main/java/com/thundermoose/plugins/paths/ProjectPaths.java
+++ b/src/main/java/com/thundermoose/plugins/paths/ProjectPaths.java
@@ -15,10 +15,7 @@ public class ProjectPaths implements Paths {
   @Matches({"/rest/api/1.0/projects/*/permissions/**"})
   private boolean permissions;
   @XmlElement
-  @Matches({
-    "/rest/api/1.0/projects/*/repos",
-    "/rest/api/1.0/projects/*/repos/*",
-  })
+  @Matches({"/rest/api/1.0/projects/*/repos"})
   private boolean repoList;
 
   public ProjectPaths() {

--- a/src/main/java/com/thundermoose/plugins/paths/ProjectPaths.java
+++ b/src/main/java/com/thundermoose/plugins/paths/ProjectPaths.java
@@ -15,7 +15,10 @@ public class ProjectPaths implements Paths {
   @Matches({"/rest/api/1.0/projects/*/permissions/**"})
   private boolean permissions;
   @XmlElement
-  @Matches({"/rest/api/1.0/projects/*/repos"})
+  @Matches({
+    "/rest/api/1.0/projects/*/repos",
+    "/rest/api/1.0/projects/*/repos/*",
+  })
   private boolean repoList;
 
   public ProjectPaths() {

--- a/src/main/java/com/thundermoose/plugins/paths/RepoPaths.java
+++ b/src/main/java/com/thundermoose/plugins/paths/RepoPaths.java
@@ -47,15 +47,16 @@ public class RepoPaths implements Paths {
 
   @XmlElement
   @Matches({"/rest/api/1.0/projects/*/repos/*"})
-  private boolean project;
+  private boolean baseDetails;
 
-  public RepoPaths(boolean permissions, boolean commitHistory, boolean files, boolean pullRequests, boolean branchPermissions, boolean buildStatus) {
+  public RepoPaths(boolean permissions, boolean commitHistory, boolean files, boolean pullRequests, boolean branchPermissions, boolean buildStatus, boolean baseDetails) {
     this.permissions = permissions;
     this.commitHistory = commitHistory;
     this.files = files;
     this.pullRequests = pullRequests;
     this.branchPermissions = branchPermissions;
     this.buildStatus = buildStatus;
+    this.baseDetails = baseDetails;
   }
 
   public RepoPaths() {
@@ -109,7 +110,11 @@ public class RepoPaths implements Paths {
     this.buildStatus = buildStatus;
   }
 
-  public void setProject(boolean project) {
-    this.project = project;
+  public boolean getBaseDetails() {
+    return baseDetails;
+  }
+
+  public void setBaseDetails(boolean baseDetails) {
+    this.baseDetails = baseDetails;
   }
 }

--- a/src/main/java/com/thundermoose/plugins/paths/RepoPaths.java
+++ b/src/main/java/com/thundermoose/plugins/paths/RepoPaths.java
@@ -45,6 +45,10 @@ public class RepoPaths implements Paths {
   @Matches({"/rest/build-status/1.0/commits/**"})
   private boolean buildStatus;
 
+  @XmlElement
+  @Matches({"/rest/api/1.0/projects/*/repos/*"})
+  private boolean project;
+
   public RepoPaths(boolean permissions, boolean commitHistory, boolean files, boolean pullRequests, boolean branchPermissions, boolean buildStatus) {
     this.permissions = permissions;
     this.commitHistory = commitHistory;
@@ -103,5 +107,9 @@ public class RepoPaths implements Paths {
 
   public void setBuildStatus(boolean buildStatus) {
     this.buildStatus = buildStatus;
+  }
+
+  public void setProject(boolean project) {
+    this.project = project;
   }
 }

--- a/src/main/resources/admin.html
+++ b/src/main/resources/admin.html
@@ -138,6 +138,12 @@
 
             <div class="description">$i18n.getText("admin.paths.repo.buildStatus.description")</div>
           </div>
+          <div class="checkbox">
+            <input type="checkbox" id="repo.baseDetails" name="repo.baseDetails" value="true">
+            <label for="repo.baseDetails">$i18n.getText("admin.paths.repo.baseDetails.label")</label>
+
+            <div class="description">$i18n.getText("admin.paths.repo.baseDetails.description")</div>
+          </div>
         </td>
       </tr>
       </tbody>

--- a/src/main/resources/com/thundermoose/plugins/i18n.properties
+++ b/src/main/resources/com/thundermoose/plugins/i18n.properties
@@ -29,7 +29,8 @@ admin.paths.project.permissions.description=/rest/api/1.0/projects/'{'projectKey
 admin.paths.project.projectList.label=Project List
 admin.paths.project.projectList.description=/rest/api/1.0/projects
 admin.paths.project.repoList.label=Repo List
-admin.paths.project.repoList.description=/rest/api/1.0/projects/'{'projectKey'}'/repos
+admin.paths.project.repoList.description=/rest/api/1.0/projects/'{'projectKey'}'/repos <br/> \
+/rest/api/1.0/projects/'{'projectKey'}'/repos/'{'repositorySlug'}'
 admin.paths.repo.permissions.label=Permissions
 admin.paths.repo.permissions.description=/rest/api/1.0/projects/'{'projectKey'}'/repos/'{'repositorySlug'}'/permissions/*
 admin.paths.repo.settings.label=Settings
@@ -55,5 +56,7 @@ admin.paths.repo.branchPermissions.description=/rest/branch-permissions/1.0/proj
 /rest/branch-permissions/2.0/projects/'{'projectKey'}'/repos/'{'repositorySlug'}'/restrictions/'{id'}'
 admin.paths.repo.buildStatus.label=Build Status
 admin.paths.repo.buildStatus.description=/rest/build-status/1.0/commits/*
+admin.paths.repo.project.label=Repo Basics
+admin.paths.repo.project.description=/rest/api/1.0/projects/*/repos/*
 auth.exception.message=Token not valid
 

--- a/src/main/resources/com/thundermoose/plugins/i18n.properties
+++ b/src/main/resources/com/thundermoose/plugins/i18n.properties
@@ -55,7 +55,7 @@ admin.paths.repo.branchPermissions.description=/rest/branch-permissions/1.0/proj
 /rest/branch-permissions/2.0/projects/'{'projectKey'}'/repos/'{'repositorySlug'}'/restrictions/'{id'}'
 admin.paths.repo.buildStatus.label=Build Status
 admin.paths.repo.buildStatus.description=/rest/build-status/1.0/commits/*
-admin.paths.repo.project.label=Base Details
-admin.paths.repo.project.description=/rest/api/1.0/projects/'{'projectKey'}'/repos/'{'repositorySlug'}'
+admin.paths.repo.baseDetails.label=Base Details
+admin.paths.repo.baseDetails.description=/rest/api/1.0/projects/'{'projectKey'}'/repos/*
 auth.exception.message=Token not valid
 

--- a/src/main/resources/com/thundermoose/plugins/i18n.properties
+++ b/src/main/resources/com/thundermoose/plugins/i18n.properties
@@ -29,8 +29,7 @@ admin.paths.project.permissions.description=/rest/api/1.0/projects/'{'projectKey
 admin.paths.project.projectList.label=Project List
 admin.paths.project.projectList.description=/rest/api/1.0/projects
 admin.paths.project.repoList.label=Repo List
-admin.paths.project.repoList.description=/rest/api/1.0/projects/'{'projectKey'}'/repos <br/> \
-/rest/api/1.0/projects/'{'projectKey'}'/repos/'{'repositorySlug'}'
+admin.paths.project.repoList.description=/rest/api/1.0/projects/'{'projectKey'}'/repos
 admin.paths.repo.permissions.label=Permissions
 admin.paths.repo.permissions.description=/rest/api/1.0/projects/'{'projectKey'}'/repos/'{'repositorySlug'}'/permissions/*
 admin.paths.repo.settings.label=Settings
@@ -56,7 +55,7 @@ admin.paths.repo.branchPermissions.description=/rest/branch-permissions/1.0/proj
 /rest/branch-permissions/2.0/projects/'{'projectKey'}'/repos/'{'repositorySlug'}'/restrictions/'{id'}'
 admin.paths.repo.buildStatus.label=Build Status
 admin.paths.repo.buildStatus.description=/rest/build-status/1.0/commits/*
-admin.paths.repo.project.label=Repo Basics
-admin.paths.repo.project.description=/rest/api/1.0/projects/*/repos/*
+admin.paths.repo.project.label=Base Details
+admin.paths.repo.project.description=/rest/api/1.0/projects/'{'projectKey'}'/repos/'{'repositorySlug'}'
 auth.exception.message=Token not valid
 

--- a/src/test/java/com/thundermoose/plugins/TokenAuthenticationHandlerTest.java
+++ b/src/test/java/com/thundermoose/plugins/TokenAuthenticationHandlerTest.java
@@ -54,7 +54,7 @@ public class TokenAuthenticationHandlerTest {
     adminConfig.setKey(new KeyGenerator().generateKey());
     adminConfig.setAdminPaths(new AdminPaths(true, true, true, true));
     adminConfig.setProjectPaths(new ProjectPaths(true, true, true));
-    adminConfig.setRepoPaths(new RepoPaths(true, true, true, true, true, true));
+    adminConfig.setRepoPaths(new RepoPaths(true, true, true, true, true, true, true));
   }
 
   @Test

--- a/src/test/java/com/thundermoose/plugins/paths/PathMatcherTest.java
+++ b/src/test/java/com/thundermoose/plugins/paths/PathMatcherTest.java
@@ -86,4 +86,15 @@ public class PathMatcherTest {
     assertTrue(sut.pathAllowed("/rest/build-status/1.0/commits/stats/dsf89h2fsdf"));
     assertTrue(sut.pathAllowed("/rest/build-status/1.0/commits/8sd9jcsadfsdf"));
   }
+
+  @Test
+  public void testBaseDetails() {
+    RepoPaths repoPaths = new RepoPaths();
+    repoPaths.setBaseDetails(true);
+
+    PathMatcher sut = new PathMatcher(repoPaths);
+
+    assertTrue(sut.pathAllowed("/rest/api/1.0/projects/PROJECT/repos/REPOSITORY"));
+    assertTrue(sut.pathAllowed("/rest/api/1.0/projects/PROJECT_ANOTHER/repos/REPOSITORY_ANOTHER"));
+  }
 }


### PR DESCRIPTION
Addresses #11.

Adds a new section under Repos called Base Details that allows for support of this pattern `/rest/api/1.0/projects/*/repos/*`. This REST API supports GET, POST, PUT, and DELTE.

Added a new test for this pattern.

Also added minor updates to the README about the `/rest/auth-token/1.0/*` REST APIs.

I have successfully packaged these changes with `atlas-package`. My manual testing has confirmed that the changes work correctly.