### PR TITLE
Add repository path for retrieving participants

### DIFF
--- a/src/main/java/com/thundermoose/plugins/admin/AdminConfigDao.java
+++ b/src/main/java/com/thundermoose/plugins/admin/AdminConfigDao.java
@@ -40,7 +40,7 @@ public class AdminConfigDao {
       config.setProjectPaths(new ProjectPaths(true, true, true));
     }
     if(config.getRepoPaths() == null) {
-      config.setRepoPaths(new RepoPaths(true, true, true, true, true, true, true));
+      config.setRepoPaths(new RepoPaths(true, true, true, true, true, true, true, true));
     }
     if(config.getSSHPaths() == null) {
       config.setSSHPaths(new SSHPaths(true, true));
@@ -87,6 +87,7 @@ public class AdminConfigDao {
                 BooleanUtils.toBoolean((String) settings.get(repoCommitHistory)),
                 BooleanUtils.toBoolean((String) settings.get(repoFiles)),
                 BooleanUtils.toBoolean((String) settings.get(repoPullRequests)),
+                BooleanUtils.toBoolean((String) settings.get(repoParticipants)),
                 BooleanUtils.toBoolean((String) settings.get(repoBranchPermissions)),
                 BooleanUtils.toBoolean((String) settings.get(repoBuildStatus)),
                 BooleanUtils.toBoolean((String) settings.get(repoBaseDetails))
@@ -135,6 +136,7 @@ public class AdminConfigDao {
           settings.put(repoCommitHistory, BooleanUtils.toStringTrueFalse(config.getRepoPaths().getCommitHistory()));
           settings.put(repoFiles, BooleanUtils.toStringTrueFalse(config.getRepoPaths().getFiles()));
           settings.put(repoPullRequests, BooleanUtils.toStringTrueFalse(config.getRepoPaths().getPullRequests()));
+          settings.put(repoParticipants, BooleanUtils.toStringTrueFalse(config.getRepoPaths().getParticipants()));
           settings.put(repoBranchPermissions, BooleanUtils.toStringTrueFalse(config.getRepoPaths().getBranchPermissions()));
           settings.put(repoBuildStatus, BooleanUtils.toStringTrueFalse(config.getRepoPaths().getBuildStatus()));
           settings.put(repoBaseDetails, BooleanUtils.toStringTrueFalse(config.getRepoPaths().getBaseDetails()));
@@ -178,6 +180,7 @@ public class AdminConfigDao {
   public static final String repoCommitHistory = repoPathPrefix + ".commitHistory";
   public static final String repoFiles = repoPathPrefix + ".files";
   public static final String repoPullRequests = repoPathPrefix + ".pullRequests";
+  public static final String repoParticipants = repoPathPrefix + ".participants";
   public static final String repoBranchPermissions = repoPathPrefix + ".branchPermissions";
   public static final String repoBuildStatus = repoPathPrefix + ".buildStatus";
   public static final String repoBaseDetails = repoPathPrefix + ".baseDetails";

--- a/src/main/java/com/thundermoose/plugins/paths/RepoPaths.java
+++ b/src/main/java/com/thundermoose/plugins/paths/RepoPaths.java
@@ -30,6 +30,9 @@ public class RepoPaths implements Paths {
   @XmlElement
   @Matches({"/rest/api/1.0/projects/*/repos/*/pull-requests/**"})
   private boolean pullRequests;
+  @XmlElement
+  @Matches({"/rest/api/1.0/projects/*/repos/*/participants"})
+  private boolean participants;
 
   @XmlElement
   @Matches({
@@ -49,11 +52,12 @@ public class RepoPaths implements Paths {
   @Matches({"/rest/api/1.0/projects/*/repos/*"})
   private boolean baseDetails;
 
-  public RepoPaths(boolean permissions, boolean commitHistory, boolean files, boolean pullRequests, boolean branchPermissions, boolean buildStatus, boolean baseDetails) {
+  public RepoPaths(boolean permissions, boolean commitHistory, boolean files, boolean pullRequests, boolean participants, boolean branchPermissions, boolean buildStatus, boolean baseDetails) {
     this.permissions = permissions;
     this.commitHistory = commitHistory;
     this.files = files;
     this.pullRequests = pullRequests;
+    this.participants = participants;
     this.branchPermissions = branchPermissions;
     this.buildStatus = buildStatus;
     this.baseDetails = baseDetails;
@@ -92,6 +96,14 @@ public class RepoPaths implements Paths {
 
   public void setPullRequests(boolean pullRequests) {
     this.pullRequests = pullRequests;
+  }
+
+  public boolean getParticipants() {
+    return participants;
+  }
+
+  public void setParticipants(boolean participants) {
+    this.participants = participants;
   }
 
   public boolean getBranchPermissions() {

--- a/src/main/resources/admin.html
+++ b/src/main/resources/admin.html
@@ -128,6 +128,12 @@
             <div class="description">$i18n.getText("admin.paths.repo.pullRequests.description")</div>
           </div>
           <div class="checkbox">
+            <input type="checkbox" id="repo.participants" name="repo.participants" value="true">
+            <label for="repo.participants">$i18n.getText("admin.paths.repo.participants.label")</label>
+
+            <div class="description">#set($messageHtml = $i18n.getText("admin.paths.repo.participants.description"))$messageHtml</div>
+          </div>
+          <div class="checkbox">
             <input type="checkbox" id="repo.branchPermissions" name="repo.branchPermissions" value="true">
             <label for="repo.branchPermissions">$i18n.getText("admin.paths.repo.branchPermissions.label")</label>
 

--- a/src/main/resources/com/thundermoose/plugins/i18n.properties
+++ b/src/main/resources/com/thundermoose/plugins/i18n.properties
@@ -41,6 +41,8 @@ admin.paths.repo.settings.label=Settings
 admin.paths.repo.settings.description=/rest/api/1.0/projects/'{'projectKey'}'/repos/'{'repositorySlug'}'/settings/'*'
 admin.paths.repo.pullRequests.label=Pull Requests
 admin.paths.repo.pullRequests.description=/rest/api/1.0/projects/'{'projectKey'}'/repos/'{'repositorySlug'}'/pull-requests/'*'
+admin.paths.repo.participants.label=Participants
+admin.paths.repo.participants.description=/rest/api/1.0/projects/'{'projectKey'}'/repos/'{'repositorySlug'}'/participants
 admin.paths.repo.commitHistory.label=Commit History
 admin.paths.repo.commitHistory.description=/rest/api/1.0/projects/'{'projectKey'}'/repos/'{'repositorySlug'}'/commits/'*' <br/> \
     /rest/api/1.0/projects/'{'projectKey'}'/repos/'{'repositorySlug'}'/compare/'*' <br/> \

--- a/src/test/java/com/thundermoose/plugins/TokenAuthenticationHandlerTest.java
+++ b/src/test/java/com/thundermoose/plugins/TokenAuthenticationHandlerTest.java
@@ -55,7 +55,7 @@ public class TokenAuthenticationHandlerTest {
     adminConfig.setKey(new KeyGenerator().generateKey());
     adminConfig.setAdminPaths(new AdminPaths(true, true, true, true));
     adminConfig.setProjectPaths(new ProjectPaths(true, true, true));
-    adminConfig.setRepoPaths(new RepoPaths(true, true, true, true, true, true, true));
+    adminConfig.setRepoPaths(new RepoPaths(true, true, true, true, true, true, true, true));
     adminConfig.setSSHPaths(new SSHPaths(true, true));
   }
 

--- a/src/test/java/com/thundermoose/plugins/paths/PathMatcherTest.java
+++ b/src/test/java/com/thundermoose/plugins/paths/PathMatcherTest.java
@@ -64,6 +64,26 @@ public class PathMatcherTest {
   }
 
   @Test
+  public void testParticipantsPaths() {
+    RepoPaths repoPaths = new RepoPaths();
+    repoPaths.setParticipants(true);
+
+    PathMatcher sut = new PathMatcher(repoPaths);
+
+    assertTrue(sut.pathAllowed("/rest/api/1.0/projects/PROJECT/repos/REPOSITORY/participants"));
+  }
+
+  @Test
+  public void testDisallowedParticipantsPaths() {
+    RepoPaths repoPaths = new RepoPaths();
+    repoPaths.setParticipants(false);
+
+    PathMatcher sut = new PathMatcher(repoPaths);
+
+    assertFalse(sut.pathAllowed("/rest/api/1.0/projects/PROJECT/repos/REPOSITORY/participants"));
+  }
+
+  @Test
   public void testBranchPermissionsPaths() {
     RepoPaths repoPaths = new RepoPaths();
     repoPaths.setBranchPermissions(true);


### PR DESCRIPTION
Added `/rest/api/1.0/projects/*/repos/*/participants` as allowable repository path.

Tested with Atlassian Bitbucket v4.14.5.