### PR TITLE
Add global /rest/api and /rest/branch-utils urls

### DIFF
--- a/src/main/java/com/thundermoose/plugins/admin/AdminConfigDao.java
+++ b/src/main/java/com/thundermoose/plugins/admin/AdminConfigDao.java
@@ -34,7 +34,7 @@ public class AdminConfigDao {
       config.setTtl(30);
     }
     if(config.getAdminPaths() == null) {
-      config.setAdminPaths(new AdminPaths(true, true, true, true));
+      config.setAdminPaths(new AdminPaths(true, true, true, true, false, false));
     }
     if(config.getProjectPaths() == null) {
       config.setProjectPaths(new ProjectPaths(true, true, true));
@@ -69,7 +69,9 @@ public class AdminConfigDao {
                 BooleanUtils.toBoolean((String) settings.get(adminPermissions)),
                 BooleanUtils.toBoolean((String) settings.get(adminUsers)),
                 BooleanUtils.toBoolean((String) settings.get(adminGroups)),
-                BooleanUtils.toBoolean((String) settings.get(adminLogs))
+                BooleanUtils.toBoolean((String) settings.get(adminLogs)),
+                BooleanUtils.toBoolean((String) settings.get(adminAllRestApi)),
+                BooleanUtils.toBoolean((String) settings.get(adminAllBranchUtilsApi))
             ));
           }
 
@@ -121,6 +123,8 @@ public class AdminConfigDao {
           settings.put(adminUsers, BooleanUtils.toStringTrueFalse(config.getAdminPaths().getUsers()));
           settings.put(adminGroups, BooleanUtils.toStringTrueFalse(config.getAdminPaths().getGroups()));
           settings.put(adminLogs, BooleanUtils.toStringTrueFalse(config.getAdminPaths().getLogs()));
+          settings.put(adminAllRestApi, BooleanUtils.toStringTrueFalse(config.getAdminPaths().getAllRestApi()));
+          settings.put(adminAllBranchUtilsApi, BooleanUtils.toStringTrueFalse(config.getAdminPaths().getAllBranchUtilsApi()));
         }
 
         if(config.getProjectPaths() != null) {
@@ -169,6 +173,8 @@ public class AdminConfigDao {
   public static final String adminUsers = adminPathPrefix + ".users";
   public static final String adminGroups = adminPathPrefix + ".groups";
   public static final String adminLogs = adminPathPrefix + ".logs";
+  public static final String adminAllRestApi = adminPathPrefix + ".allRestApi";
+  public static final String adminAllBranchUtilsApi = adminPathPrefix + ".allBranchUtilsApi";
 
   public static final String projectPathPrefix = ".projectPaths";
   public static final String projectList = projectPathPrefix + ".projectList";

--- a/src/main/java/com/thundermoose/plugins/admin/AdminConfigDao.java
+++ b/src/main/java/com/thundermoose/plugins/admin/AdminConfigDao.java
@@ -34,7 +34,7 @@ public class AdminConfigDao {
       config.setTtl(30);
     }
     if(config.getAdminPaths() == null) {
-      config.setAdminPaths(new AdminPaths(true, true, true, true, false, false));
+      config.setAdminPaths(new AdminPaths(true, true, true, true, false, false, false));
     }
     if(config.getProjectPaths() == null) {
       config.setProjectPaths(new ProjectPaths(true, true, true));
@@ -71,7 +71,8 @@ public class AdminConfigDao {
                 BooleanUtils.toBoolean((String) settings.get(adminGroups)),
                 BooleanUtils.toBoolean((String) settings.get(adminLogs)),
                 BooleanUtils.toBoolean((String) settings.get(adminAllRestApi)),
-                BooleanUtils.toBoolean((String) settings.get(adminAllBranchUtilsApi))
+                BooleanUtils.toBoolean((String) settings.get(adminAllBranchUtilsApi)),
+                BooleanUtils.toBoolean((String) settings.get(adminAllKeysApi))
             ));
           }
 
@@ -125,6 +126,7 @@ public class AdminConfigDao {
           settings.put(adminLogs, BooleanUtils.toStringTrueFalse(config.getAdminPaths().getLogs()));
           settings.put(adminAllRestApi, BooleanUtils.toStringTrueFalse(config.getAdminPaths().getAllRestApi()));
           settings.put(adminAllBranchUtilsApi, BooleanUtils.toStringTrueFalse(config.getAdminPaths().getAllBranchUtilsApi()));
+          settings.put(adminAllKeysApi, BooleanUtils.toStringTrueFalse(config.getAdminPaths().getAllKeysApi()));
         }
 
         if(config.getProjectPaths() != null) {
@@ -175,6 +177,7 @@ public class AdminConfigDao {
   public static final String adminLogs = adminPathPrefix + ".logs";
   public static final String adminAllRestApi = adminPathPrefix + ".allRestApi";
   public static final String adminAllBranchUtilsApi = adminPathPrefix + ".allBranchUtilsApi";
+  public static final String adminAllKeysApi = adminPathPrefix + ".allKeysApi";
 
   public static final String projectPathPrefix = ".projectPaths";
   public static final String projectList = projectPathPrefix + ".projectList";

--- a/src/main/java/com/thundermoose/plugins/admin/AdminConfigDao.java
+++ b/src/main/java/com/thundermoose/plugins/admin/AdminConfigDao.java
@@ -34,7 +34,7 @@ public class AdminConfigDao {
       config.setTtl(30);
     }
     if(config.getAdminPaths() == null) {
-      config.setAdminPaths(new AdminPaths(true, true, true, true, false, false, false));
+      config.setAdminPaths(new AdminPaths(true, true, true, true, false, false, false, false));
     }
     if(config.getProjectPaths() == null) {
       config.setProjectPaths(new ProjectPaths(true, true, true));
@@ -72,7 +72,8 @@ public class AdminConfigDao {
                 BooleanUtils.toBoolean((String) settings.get(adminLogs)),
                 BooleanUtils.toBoolean((String) settings.get(adminAllRestApi)),
                 BooleanUtils.toBoolean((String) settings.get(adminAllBranchUtilsApi)),
-                BooleanUtils.toBoolean((String) settings.get(adminAllKeysApi))
+                BooleanUtils.toBoolean((String) settings.get(adminAllKeysApi)),
+                BooleanUtils.toBoolean((String) settings.get(adminAllDefaultReviewersApi))
             ));
           }
 
@@ -127,6 +128,7 @@ public class AdminConfigDao {
           settings.put(adminAllRestApi, BooleanUtils.toStringTrueFalse(config.getAdminPaths().getAllRestApi()));
           settings.put(adminAllBranchUtilsApi, BooleanUtils.toStringTrueFalse(config.getAdminPaths().getAllBranchUtilsApi()));
           settings.put(adminAllKeysApi, BooleanUtils.toStringTrueFalse(config.getAdminPaths().getAllKeysApi()));
+          settings.put(adminAllDefaultReviewersApi, BooleanUtils.toStringTrueFalse(config.getAdminPaths().getAllDefaultReviewersApi()));
         }
 
         if(config.getProjectPaths() != null) {
@@ -178,6 +180,7 @@ public class AdminConfigDao {
   public static final String adminAllRestApi = adminPathPrefix + ".allRestApi";
   public static final String adminAllBranchUtilsApi = adminPathPrefix + ".allBranchUtilsApi";
   public static final String adminAllKeysApi = adminPathPrefix + ".allKeysApi";
+  public static final String adminAllDefaultReviewersApi = adminPathPrefix + ".allDefaultReviewersApi";
 
   public static final String projectPathPrefix = ".projectPaths";
   public static final String projectList = projectPathPrefix + ".projectList";

--- a/src/main/java/com/thundermoose/plugins/admin/AdminConfigDao.java
+++ b/src/main/java/com/thundermoose/plugins/admin/AdminConfigDao.java
@@ -34,7 +34,7 @@ public class AdminConfigDao {
       config.setTtl(30);
     }
     if(config.getAdminPaths() == null) {
-      config.setAdminPaths(new AdminPaths(true, true, true, true, false, false, false, false));
+      config.setAdminPaths(new AdminPaths(true, true, true, true, false, false, false, false, false));
     }
     if(config.getProjectPaths() == null) {
       config.setProjectPaths(new ProjectPaths(true, true, true));
@@ -73,7 +73,8 @@ public class AdminConfigDao {
                 BooleanUtils.toBoolean((String) settings.get(adminAllRestApi)),
                 BooleanUtils.toBoolean((String) settings.get(adminAllBranchUtilsApi)),
                 BooleanUtils.toBoolean((String) settings.get(adminAllKeysApi)),
-                BooleanUtils.toBoolean((String) settings.get(adminAllDefaultReviewersApi))
+                BooleanUtils.toBoolean((String) settings.get(adminAllDefaultReviewersApi)),
+                BooleanUtils.toBoolean((String) settings.get(adminAllBranchPermissionsApi))
             ));
           }
 
@@ -129,6 +130,7 @@ public class AdminConfigDao {
           settings.put(adminAllBranchUtilsApi, BooleanUtils.toStringTrueFalse(config.getAdminPaths().getAllBranchUtilsApi()));
           settings.put(adminAllKeysApi, BooleanUtils.toStringTrueFalse(config.getAdminPaths().getAllKeysApi()));
           settings.put(adminAllDefaultReviewersApi, BooleanUtils.toStringTrueFalse(config.getAdminPaths().getAllDefaultReviewersApi()));
+          settings.put(adminAllBranchPermissionsApi, BooleanUtils.toStringTrueFalse(config.getAdminPaths().getAllBranchPermissionsApi()));
         }
 
         if(config.getProjectPaths() != null) {
@@ -181,6 +183,7 @@ public class AdminConfigDao {
   public static final String adminAllBranchUtilsApi = adminPathPrefix + ".allBranchUtilsApi";
   public static final String adminAllKeysApi = adminPathPrefix + ".allKeysApi";
   public static final String adminAllDefaultReviewersApi = adminPathPrefix + ".allDefaultReviewersApi";
+  public static final String adminAllBranchPermissionsApi = adminPathPrefix + ".adminAllBranchPermissionsApi";
 
   public static final String projectPathPrefix = ".projectPaths";
   public static final String projectList = projectPathPrefix + ".projectList";

--- a/src/main/java/com/thundermoose/plugins/paths/AdminPaths.java
+++ b/src/main/java/com/thundermoose/plugins/paths/AdminPaths.java
@@ -26,14 +26,18 @@ public class AdminPaths implements Paths {
   @XmlElement
   @Matches({"/rest/branch-utils/1.0/**"})
   private boolean allBranchUtilsApi;
+  @XmlElement
+  @Matches({"/rest/keys/1.0/**"})
+  private boolean allKeysApi;
 
-  public AdminPaths(boolean permissions, boolean users, boolean groups, boolean logs, boolean allRestApi, boolean allBranchUtilsApi) {
+  public AdminPaths(boolean permissions, boolean users, boolean groups, boolean logs, boolean allRestApi, boolean allBranchUtilsApi, boolean  allKeysApi) {
     this.permissions = permissions;
     this.users = users;
     this.groups = groups;
     this.logs = logs;
     this.allRestApi = allRestApi;
     this.allBranchUtilsApi = allBranchUtilsApi;
+    this.allKeysApi = allKeysApi;
   }
 
   public AdminPaths() {
@@ -85,5 +89,13 @@ public class AdminPaths implements Paths {
 
   public void setAllBranchUtilsApi(boolean allBranchUtilsApi) {
     this.allBranchUtilsApi = allBranchUtilsApi;
+  }
+
+  public boolean getAllKeysApi() {
+    return allKeysApi;
+  }
+
+  public void setAllKeysApi(boolean allKeysApi) {
+    this.allKeysApi = allKeysApi;
   }
 }

--- a/src/main/java/com/thundermoose/plugins/paths/AdminPaths.java
+++ b/src/main/java/com/thundermoose/plugins/paths/AdminPaths.java
@@ -29,8 +29,11 @@ public class AdminPaths implements Paths {
   @XmlElement
   @Matches({"/rest/keys/1.0/**"})
   private boolean allKeysApi;
+  @XmlElement
+  @Matches({"/rest/default-reviewers/1.0/**"})
+  private boolean allDefaultReviewersApi;
 
-  public AdminPaths(boolean permissions, boolean users, boolean groups, boolean logs, boolean allRestApi, boolean allBranchUtilsApi, boolean  allKeysApi) {
+  public AdminPaths(boolean permissions, boolean users, boolean groups, boolean logs, boolean allRestApi, boolean allBranchUtilsApi, boolean  allKeysApi, boolean allDefaultReviewersApi) {
     this.permissions = permissions;
     this.users = users;
     this.groups = groups;
@@ -38,6 +41,7 @@ public class AdminPaths implements Paths {
     this.allRestApi = allRestApi;
     this.allBranchUtilsApi = allBranchUtilsApi;
     this.allKeysApi = allKeysApi;
+    this.allDefaultReviewersApi = allDefaultReviewersApi;
   }
 
   public AdminPaths() {
@@ -97,5 +101,13 @@ public class AdminPaths implements Paths {
 
   public void setAllKeysApi(boolean allKeysApi) {
     this.allKeysApi = allKeysApi;
+  }
+
+  public boolean getAllDefaultReviewersApi() {
+    return allDefaultReviewersApi;
+  }
+
+  public void setAllDefaultReviewersApi(boolean allDefaultReviewersApi) {
+    this.allDefaultReviewersApi = allDefaultReviewersApi;
   }
 }

--- a/src/main/java/com/thundermoose/plugins/paths/AdminPaths.java
+++ b/src/main/java/com/thundermoose/plugins/paths/AdminPaths.java
@@ -32,8 +32,11 @@ public class AdminPaths implements Paths {
   @XmlElement
   @Matches({"/rest/default-reviewers/1.0/**"})
   private boolean allDefaultReviewersApi;
+  @XmlElement
+  @Matches({"/rest/branch-permissions/2.0/**"})
+  private boolean allBranchPermissionsApi;
 
-  public AdminPaths(boolean permissions, boolean users, boolean groups, boolean logs, boolean allRestApi, boolean allBranchUtilsApi, boolean  allKeysApi, boolean allDefaultReviewersApi) {
+  public AdminPaths(boolean permissions, boolean users, boolean groups, boolean logs, boolean allRestApi, boolean allBranchUtilsApi, boolean allKeysApi, boolean allDefaultReviewersApi, boolean allBranchPermissionsApi) {
     this.permissions = permissions;
     this.users = users;
     this.groups = groups;
@@ -42,6 +45,7 @@ public class AdminPaths implements Paths {
     this.allBranchUtilsApi = allBranchUtilsApi;
     this.allKeysApi = allKeysApi;
     this.allDefaultReviewersApi = allDefaultReviewersApi;
+    this.allBranchPermissionsApi = allBranchPermissionsApi;
   }
 
   public AdminPaths() {
@@ -109,5 +113,13 @@ public class AdminPaths implements Paths {
 
   public void setAllDefaultReviewersApi(boolean allDefaultReviewersApi) {
     this.allDefaultReviewersApi = allDefaultReviewersApi;
+  }
+
+  public boolean getAllBranchPermissionsApi() {
+    return allBranchPermissionsApi;
+  }
+
+  public void setAllBranchPermissionsApi(boolean allBranchPermissionsApi) {
+    this.allBranchPermissionsApi = allBranchPermissionsApi;
   }
 }

--- a/src/main/java/com/thundermoose/plugins/paths/AdminPaths.java
+++ b/src/main/java/com/thundermoose/plugins/paths/AdminPaths.java
@@ -20,12 +20,20 @@ public class AdminPaths implements Paths {
   @XmlElement
   @Matches({"/rest/api/1.0/admin/logs/**"})
   private boolean logs;
+  @XmlElement
+  @Matches({"/rest/api/1.0/**"})
+  private boolean allRestApi;
+  @XmlElement
+  @Matches({"/rest/branch-utils/1.0/**"})
+  private boolean allBranchUtilsApi;
 
-  public AdminPaths(boolean permissions, boolean users, boolean groups, boolean logs) {
+  public AdminPaths(boolean permissions, boolean users, boolean groups, boolean logs, boolean allRestApi, boolean allBranchUtilsApi) {
     this.permissions = permissions;
     this.users = users;
     this.groups = groups;
     this.logs = logs;
+    this.allRestApi = allRestApi;
+    this.allBranchUtilsApi = allBranchUtilsApi;
   }
 
   public AdminPaths() {
@@ -61,5 +69,21 @@ public class AdminPaths implements Paths {
 
   public void setLogs(boolean logs) {
     this.logs = logs;
+  }
+
+  public boolean getAllRestApi() {
+    return allRestApi;
+  }
+
+  public void setAllRestApi(boolean allRestApi) {
+    this.allRestApi = allRestApi;
+  }
+
+  public boolean getAllBranchUtilsApi() {
+    return allBranchUtilsApi;
+  }
+
+  public void setAllBranchUtilsApi(boolean allBranchUtilsApi) {
+    this.allBranchUtilsApi = allBranchUtilsApi;
   }
 }

--- a/src/main/resources/admin.html
+++ b/src/main/resources/admin.html
@@ -105,6 +105,12 @@
 
             <div class="description">$i18n.getText("admin.paths.admin.allDefaultReviewersApi.description")</div>
           </div>
+          <div class="checkbox">
+            <input type="checkbox" id="admin.allBranchPermissionsApi" name="admin.allBranchPermissionsApi" value="true">
+            <label for="admin.allBranchPermissionsApi">$i18n.getText("admin.paths.admin.allBranchPermissionsApi.label")</label>
+
+            <div class="description">$i18n.getText("admin.paths.admin.allBranchPermissionsApi.description")</div>
+          </div>
         </td>
         <td>
           <div class="checkbox">

--- a/src/main/resources/admin.html
+++ b/src/main/resources/admin.html
@@ -81,6 +81,18 @@
 
             <div class="description">#set($messageHtml = $i18n.getText('admin.paths.admin.logs.description'))$messageHtml</div>
           </div>
+          <div class="checkbox">
+            <input type="checkbox" id="admin.allRestApi" name="admin.allRestApi" value="true">
+            <label for="admin.allRestApi">$i18n.getText("admin.paths.admin.allRestApi.label")</label>
+
+            <div class="description">$i18n.getText("admin.paths.admin.allRestApi.description")</div>
+          </div>
+          <div class="checkbox">
+            <input type="checkbox" id="admin.allBranchUtilsApi" name="admin.allBranchUtilsApi" value="true">
+            <label for="admin.allBranchUtilsApi">$i18n.getText("admin.paths.admin.allBranchUtilsApi.label")</label>
+
+            <div class="description">$i18n.getText("admin.paths.admin.allBranchUtilsApi.description")</div>
+          </div>
         </td>
         <td>
           <div class="checkbox">

--- a/src/main/resources/admin.html
+++ b/src/main/resources/admin.html
@@ -99,6 +99,12 @@
 
             <div class="description">$i18n.getText("admin.paths.admin.allKeysApi.description")</div>
           </div>
+          <div class="checkbox">
+            <input type="checkbox" id="admin.allDefaultReviewersApi" name="admin.allDefaultReviewersApi" value="true">
+            <label for="admin.allDefaultReviewersApi">$i18n.getText("admin.paths.admin.allDefaultReviewersApi.label")</label>
+
+            <div class="description">$i18n.getText("admin.paths.admin.allDefaultReviewersApi.description")</div>
+          </div>
         </td>
         <td>
           <div class="checkbox">

--- a/src/main/resources/admin.html
+++ b/src/main/resources/admin.html
@@ -93,6 +93,12 @@
 
             <div class="description">$i18n.getText("admin.paths.admin.allBranchUtilsApi.description")</div>
           </div>
+          <div class="checkbox">
+            <input type="checkbox" id="admin.allKeysApi" name="admin.allKeysApi" value="true">
+            <label for="admin.allKeysApi">$i18n.getText("admin.paths.admin.allKeysApi.label")</label>
+
+            <div class="description">$i18n.getText("admin.paths.admin.allKeysApi.description")</div>
+          </div>
         </td>
         <td>
           <div class="checkbox">

--- a/src/main/resources/com/thundermoose/plugins/i18n.properties
+++ b/src/main/resources/com/thundermoose/plugins/i18n.properties
@@ -27,12 +27,14 @@ admin.paths.admin.users.label=Users
 admin.paths.admin.users.description=/rest/api/1.0/admin/users/'*'
 admin.paths.admin.logs.label=Logs
 admin.paths.admin.logs.description=/rest/api/1.0/logs/'*
-admin.paths.admin.allRestApi.label=All REST API
+admin.paths.admin.allRestApi.label=All REST API endpoints
 admin.paths.admin.allRestApi.description=/rest/api/1.0/'*'
-admin.paths.admin.allBranchUtilsApi.label=All Branch utils API
+admin.paths.admin.allBranchUtilsApi.label=All Branch utils API endpoints
 admin.paths.admin.allBranchUtilsApi.description=/rest/branch-utils/1.0/'*'
-admin.paths.admin.allKeysApi.label=All keys API
+admin.paths.admin.allKeysApi.label=All keys API endpoints
 admin.paths.admin.allKeysApi.description=/rest/keys/1.0/'*'
+admin.paths.admin.allDefaultReviewersApi.label=All default reviewers API endpoints
+admin.paths.admin.allDefaultReviewersApi.description=/rest/default-reviewers/1.0/'*'
 
 admin.paths.project.permissions.label=Permissions
 admin.paths.project.permissions.description=/rest/api/1.0/projects/'{'projectKey'}'/permissions/'*'

--- a/src/main/resources/com/thundermoose/plugins/i18n.properties
+++ b/src/main/resources/com/thundermoose/plugins/i18n.properties
@@ -35,6 +35,8 @@ admin.paths.admin.allKeysApi.label=All keys API endpoints
 admin.paths.admin.allKeysApi.description=/rest/keys/1.0/'*'
 admin.paths.admin.allDefaultReviewersApi.label=All default reviewers API endpoints
 admin.paths.admin.allDefaultReviewersApi.description=/rest/default-reviewers/1.0/'*'
+admin.paths.admin.allBranchPermissionsApi.label=All branch permissions API endpoints
+admin.paths.admin.allBranchPermissionsApi.description=/rest/branch-permissions/2.0/'*'
 
 admin.paths.project.permissions.label=Permissions
 admin.paths.project.permissions.description=/rest/api/1.0/projects/'{'projectKey'}'/permissions/'*'

--- a/src/main/resources/com/thundermoose/plugins/i18n.properties
+++ b/src/main/resources/com/thundermoose/plugins/i18n.properties
@@ -31,6 +31,8 @@ admin.paths.admin.allRestApi.label=All REST API
 admin.paths.admin.allRestApi.description=/rest/api/1.0/'*'
 admin.paths.admin.allBranchUtilsApi.label=All Branch utils API
 admin.paths.admin.allBranchUtilsApi.description=/rest/branch-utils/1.0/'*'
+admin.paths.admin.allKeysApi.label=All keys API
+admin.paths.admin.allKeysApi.description=/rest/keys/1.0/'*'
 
 admin.paths.project.permissions.label=Permissions
 admin.paths.project.permissions.description=/rest/api/1.0/projects/'{'projectKey'}'/permissions/'*'

--- a/src/main/resources/com/thundermoose/plugins/i18n.properties
+++ b/src/main/resources/com/thundermoose/plugins/i18n.properties
@@ -26,7 +26,11 @@ admin.paths.admin.groups.description=/rest/api/1.0/admin/groups/'*'
 admin.paths.admin.users.label=Users
 admin.paths.admin.users.description=/rest/api/1.0/admin/users/'*'
 admin.paths.admin.logs.label=Logs
-admin.paths.admin.logs.description=/rest/api/1.0/logs/'*'
+admin.paths.admin.logs.description=/rest/api/1.0/logs/'*
+admin.paths.admin.allRestApi.label=All REST API
+admin.paths.admin.allRestApi.description=/rest/api/1.0/'*'
+admin.paths.admin.allBranchUtilsApi.label=All Branch utils API
+admin.paths.admin.allBranchUtilsApi.description=/rest/branch-utils/1.0/'*'
 
 admin.paths.project.permissions.label=Permissions
 admin.paths.project.permissions.description=/rest/api/1.0/projects/'{'projectKey'}'/permissions/'*'
@@ -72,4 +76,3 @@ admin.paths.ssh.repoKeys.label=Repo Keys
 admin.paths.ssh.repoKeys.description=/rest/keys/1.0/ssh/'{'keyId'}'/'*' <br/> \
     /rest/keys/1.0/projects/'{'projectKey'}'/ssh/'*' <br/> \
     /rest/keys/1.0/projects/'{'projectKey'}'/repos/'{'repositorySlug'}'/ssh/'*'
-

--- a/src/test/java/com/thundermoose/plugins/TokenAuthenticationHandlerTest.java
+++ b/src/test/java/com/thundermoose/plugins/TokenAuthenticationHandlerTest.java
@@ -53,7 +53,7 @@ public class TokenAuthenticationHandlerTest {
     adminConfig.setTtl(10);
     adminConfig.setEnabled(true);
     adminConfig.setKey(new KeyGenerator().generateKey());
-    adminConfig.setAdminPaths(new AdminPaths(true, true, true, true, false, false, false));
+    adminConfig.setAdminPaths(new AdminPaths(true, true, true, true, false, false, false, false));
     adminConfig.setProjectPaths(new ProjectPaths(true, true, true));
     adminConfig.setRepoPaths(new RepoPaths(true, true, true, true, true, true, true, true));
     adminConfig.setSSHPaths(new SSHPaths(true, true));

--- a/src/test/java/com/thundermoose/plugins/TokenAuthenticationHandlerTest.java
+++ b/src/test/java/com/thundermoose/plugins/TokenAuthenticationHandlerTest.java
@@ -53,7 +53,7 @@ public class TokenAuthenticationHandlerTest {
     adminConfig.setTtl(10);
     adminConfig.setEnabled(true);
     adminConfig.setKey(new KeyGenerator().generateKey());
-    adminConfig.setAdminPaths(new AdminPaths(true, true, true, true));
+    adminConfig.setAdminPaths(new AdminPaths(true, true, true, true, true, true));
     adminConfig.setProjectPaths(new ProjectPaths(true, true, true));
     adminConfig.setRepoPaths(new RepoPaths(true, true, true, true, true, true, true, true));
     adminConfig.setSSHPaths(new SSHPaths(true, true));

--- a/src/test/java/com/thundermoose/plugins/TokenAuthenticationHandlerTest.java
+++ b/src/test/java/com/thundermoose/plugins/TokenAuthenticationHandlerTest.java
@@ -53,7 +53,7 @@ public class TokenAuthenticationHandlerTest {
     adminConfig.setTtl(10);
     adminConfig.setEnabled(true);
     adminConfig.setKey(new KeyGenerator().generateKey());
-    adminConfig.setAdminPaths(new AdminPaths(true, true, true, true, true, true));
+    adminConfig.setAdminPaths(new AdminPaths(true, true, true, true, false, false, false));
     adminConfig.setProjectPaths(new ProjectPaths(true, true, true));
     adminConfig.setRepoPaths(new RepoPaths(true, true, true, true, true, true, true, true));
     adminConfig.setSSHPaths(new SSHPaths(true, true));

--- a/src/test/java/com/thundermoose/plugins/TokenAuthenticationHandlerTest.java
+++ b/src/test/java/com/thundermoose/plugins/TokenAuthenticationHandlerTest.java
@@ -53,7 +53,7 @@ public class TokenAuthenticationHandlerTest {
     adminConfig.setTtl(10);
     adminConfig.setEnabled(true);
     adminConfig.setKey(new KeyGenerator().generateKey());
-    adminConfig.setAdminPaths(new AdminPaths(true, true, true, true, false, false, false, false));
+    adminConfig.setAdminPaths(new AdminPaths(true, true, true, true, false, false, false, false, false));
     adminConfig.setProjectPaths(new ProjectPaths(true, true, true));
     adminConfig.setRepoPaths(new RepoPaths(true, true, true, true, true, true, true, true));
     adminConfig.setSSHPaths(new SSHPaths(true, true));


### PR DESCRIPTION
I am not sure if this is something that is desired, but we needed a way to have access to more API's and also the (non-public) branch-utils API's.

So I added two extra paths (which are disabled by default) to accommodate for this.

Any feedback is welcome