### PR TITLE
Adding DataCenter support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 *.iml
 *.ipr
 *.iws
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.thundermoose.plugins</groupId>
   <artifactId>stash-token-auth</artifactId>
-  <version>2.2</version>
+  <version>2.3-SNAPSHOT</version>
   <packaging>atlassian-plugin</packaging>
 
   <name>Token Authenticator</name>

--- a/src/main/java/com/thundermoose/plugins/admin/AdminConfigDao.java
+++ b/src/main/java/com/thundermoose/plugins/admin/AdminConfigDao.java
@@ -14,7 +14,6 @@ import org.apache.commons.lang3.BooleanUtils;
 public class AdminConfigDao {
   private final PluginSettingsFactory pluginSettingsFactory;
   private final TransactionTemplate transactionTemplate;
-  private AdminConfig cachedConfig;
 
   public AdminConfigDao(PluginSettingsFactory pluginSettingsFactory, TransactionTemplate transactionTemplate) {
     this.pluginSettingsFactory = pluginSettingsFactory;
@@ -49,68 +48,63 @@ public class AdminConfigDao {
   }
 
   public AdminConfig getAdminConfig() {
-    AdminConfig config = getCache();
-    if(config != null) {
-      return config;
-    } else {
-      return transactionTemplate.execute(new TransactionCallback<AdminConfig>() {
-        public AdminConfig doInTransaction() {
-          PluginSettings settings = pluginSettingsFactory.createGlobalSettings();
-          AdminConfig config = new AdminConfig();
-          config.setEnabled(BooleanUtils.toBoolean((String) settings.get(BASE + ".enabled")));
-          config.setKey((String) settings.get(BASE + ".key"));
-          String ttl = (String) settings.get(BASE + ".ttl");
-          if(ttl != null) {
-            config.setTtl(Integer.valueOf(ttl));
-          }
-
-          if(settings.get(adminPathPrefix) != null) {
-            config.setAdminPaths(new AdminPaths(
-                BooleanUtils.toBoolean((String) settings.get(adminPermissions)),
-                BooleanUtils.toBoolean((String) settings.get(adminUsers)),
-                BooleanUtils.toBoolean((String) settings.get(adminGroups)),
-                BooleanUtils.toBoolean((String) settings.get(adminLogs)),
-                BooleanUtils.toBoolean((String) settings.get(adminAllRestApi)),
-                BooleanUtils.toBoolean((String) settings.get(adminAllBranchUtilsApi)),
-                BooleanUtils.toBoolean((String) settings.get(adminAllKeysApi)),
-                BooleanUtils.toBoolean((String) settings.get(adminAllDefaultReviewersApi)),
-                BooleanUtils.toBoolean((String) settings.get(adminAllBranchPermissionsApi))
-            ));
-          }
-
-          if(settings.get(projectPathPrefix) != null) {
-            config.setProjectPaths(new ProjectPaths(
-                BooleanUtils.toBoolean((String) settings.get(projectList)),
-                BooleanUtils.toBoolean((String) settings.get(projectPermissions)),
-                BooleanUtils.toBoolean((String) settings.get(projectRepoList))
-            ));
-          }
-
-          if(settings.get(repoPathPrefix) != null) {
-            config.setRepoPaths(new RepoPaths(
-                BooleanUtils.toBoolean((String) settings.get(repoPermissions)),
-                BooleanUtils.toBoolean((String) settings.get(repoCommitHistory)),
-                BooleanUtils.toBoolean((String) settings.get(repoFiles)),
-                BooleanUtils.toBoolean((String) settings.get(repoPullRequests)),
-                BooleanUtils.toBoolean((String) settings.get(repoParticipants)),
-                BooleanUtils.toBoolean((String) settings.get(repoBranchPermissions)),
-                BooleanUtils.toBoolean((String) settings.get(repoBuildStatus)),
-                BooleanUtils.toBoolean((String) settings.get(repoBaseDetails)),
-                BooleanUtils.toBoolean((String) settings.get(repoSync))
-            ));
-          }
-
-          if(settings.get(sshPathPrefix) != null) {
-            config.setSSHPaths(new SSHPaths(
-                BooleanUtils.toBoolean((String) settings.get(sshUserKeys)),
-                BooleanUtils.toBoolean((String) settings.get(sshRepoKeys))
-            ));
-          }
-
-          return config;
+    return transactionTemplate.execute(new TransactionCallback<AdminConfig>() {
+      public AdminConfig doInTransaction() {
+        PluginSettings settings = pluginSettingsFactory.createGlobalSettings();
+        AdminConfig config = new AdminConfig();
+        config.setEnabled(BooleanUtils.toBoolean((String) settings.get(BASE + ".enabled")));
+        config.setKey((String) settings.get(BASE + ".key"));
+        String ttl = (String) settings.get(BASE + ".ttl");
+        if(ttl != null) {
+          config.setTtl(Integer.valueOf(ttl));
         }
-      });
-    }
+
+        if(settings.get(adminPathPrefix) != null) {
+          config.setAdminPaths(new AdminPaths(
+              BooleanUtils.toBoolean((String) settings.get(adminPermissions)),
+              BooleanUtils.toBoolean((String) settings.get(adminUsers)),
+              BooleanUtils.toBoolean((String) settings.get(adminGroups)),
+              BooleanUtils.toBoolean((String) settings.get(adminLogs)),
+              BooleanUtils.toBoolean((String) settings.get(adminAllRestApi)),
+              BooleanUtils.toBoolean((String) settings.get(adminAllBranchUtilsApi)),
+              BooleanUtils.toBoolean((String) settings.get(adminAllKeysApi)),
+              BooleanUtils.toBoolean((String) settings.get(adminAllDefaultReviewersApi)),
+              BooleanUtils.toBoolean((String) settings.get(adminAllBranchPermissionsApi))
+          ));
+        }
+
+        if(settings.get(projectPathPrefix) != null) {
+          config.setProjectPaths(new ProjectPaths(
+              BooleanUtils.toBoolean((String) settings.get(projectList)),
+              BooleanUtils.toBoolean((String) settings.get(projectPermissions)),
+              BooleanUtils.toBoolean((String) settings.get(projectRepoList))
+          ));
+        }
+
+        if(settings.get(repoPathPrefix) != null) {
+          config.setRepoPaths(new RepoPaths(
+              BooleanUtils.toBoolean((String) settings.get(repoPermissions)),
+              BooleanUtils.toBoolean((String) settings.get(repoCommitHistory)),
+              BooleanUtils.toBoolean((String) settings.get(repoFiles)),
+              BooleanUtils.toBoolean((String) settings.get(repoPullRequests)),
+              BooleanUtils.toBoolean((String) settings.get(repoParticipants)),
+              BooleanUtils.toBoolean((String) settings.get(repoBranchPermissions)),
+              BooleanUtils.toBoolean((String) settings.get(repoBuildStatus)),
+              BooleanUtils.toBoolean((String) settings.get(repoBaseDetails)),
+              BooleanUtils.toBoolean((String) settings.get(repoSync))
+          ));
+        }
+
+        if(settings.get(sshPathPrefix) != null) {
+          config.setSSHPaths(new SSHPaths(
+              BooleanUtils.toBoolean((String) settings.get(sshUserKeys)),
+              BooleanUtils.toBoolean((String) settings.get(sshRepoKeys))
+          ));
+        }
+
+        return config;
+      }
+    });
   }
 
   public void setAdminConfig(final AdminConfig config) {
@@ -159,18 +153,9 @@ public class AdminConfigDao {
           settings.put(sshRepoKeys, BooleanUtils.toStringTrueFalse(config.getSSHPaths().getRepoKeys()));
         }
 
-        setCache(config);
         return config;
       }
     });
-  }
-
-  private synchronized void setCache(AdminConfig config) {
-    this.cachedConfig = config;
-  }
-
-  private synchronized AdminConfig getCache() {
-    return this.cachedConfig;
   }
 
   public static final String BASE = AdminConfig.class.getName();

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -5,6 +5,7 @@
     <vendor name="${project.organization.name}" url="${project.organization.url}"/>
     <param name="plugin-icon">images/pluginIcon.png</param>
     <param name="plugin-logo">images/pluginIcon.png</param>
+    <param name="atlassian-data-center-compatible">true</param>
   </plugin-info>
 
   <component-import key="i18nService" interface="com.atlassian.bitbucket.i18n.I18nService"/>


### PR DESCRIPTION
This PR adds Bitbucket Data Center support to the plugin as per Issue #9.

The only real change is the removal of the `cachedConfig` field from `AdminConfigDao` which forces the plugin to fetch the current configuration from the plugin settings table every time.

A better implementation might take advantage of Bitbucket's cluster-wide caching system but I wanted to get the plugin working first.

I've tested (albeit not extensively) in our QA Bitbucket Data Center instance running v5.2.0.